### PR TITLE
improved history clean up and fade-out effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             <h2>Computer</h2>
         </div>
     </div>
-    <div data-history class="results">
+    <div data-history class="history results">
         <!-- Dynamic Part from JavaScript goes here
             <div class="result-selection winner">✊</div>
             <div class="result-selection">✌</div> -->

--- a/script.js
+++ b/script.js
@@ -5,7 +5,7 @@ const spockButton = document.getElementById('spock');
 const history = document.querySelector('[data-history]');
 const computerScore = document.querySelector('[data-computer-score]');
 const userScore = document.querySelector('[data-user-score]');
-const maxHistoryRows = 5;
+const maxHistoryRows = 8;
 const SELECTIONS = [
     {
         name: 'rock',
@@ -90,6 +90,8 @@ function incrementScore(scoreSpan) {
 
 function cleanUpBottom() {
     const historyRemovalIndex = maxHistoryRows * 2;
-    history.removeChild(history.children[historyRemovalIndex]);
-    history.removeChild(history.children[historyRemovalIndex]);
+    if (history.childElementCount > historyRemovalIndex) {
+        history.removeChild(history.children[historyRemovalIndex]);
+        history.removeChild(history.children[historyRemovalIndex]);
+    }
 }

--- a/styles.css
+++ b/styles.css
@@ -56,10 +56,26 @@ body {
 
 .result-selection {
     font-size: 2rem;
-    opacity: .5;
+    opacity: 0.6;
 }
 
 .result-selection.winner {
     font-size: 2.5rem;
     opacity: 1;
+}
+
+/* Proper Fade-out effect */
+
+/* as soon as there are 5 or more divs: */
+.history:has(.result-selection:nth-child(n+5)) {
+
+    /* styling the 5th and all following divs */
+    .result-selection:nth-of-type(n+5) {
+        opacity: 0.3;
+    }
+
+    /* styling the 9th and all following divs */
+    .result-selection:nth-of-type(n+9) {
+        opacity: 0.1;
+    }
 }


### PR DESCRIPTION
### This PR is to cover issue #4 (add children counter to history div)
Add counter of children so that `.removeChild` only fires when counter is reached (i.e. index exists)
This is to prevent console errors showing up when history is less than 5 rows

---

- added condition so that the cleanup function only fires when enough divs were added
`    if (history.childElementCount > historyRemovalIndex)`

- improved styling to create better fade-out effect
```
/* Proper Fade-out effect */

/* as soon as there are 5 or more divs: */
.history:has(.result-selection:nth-child(n+5)) {

    /* styling the 5th and all following divs */
    .result-selection:nth-of-type(n+5) {
        opacity: 0.3;
    }

    /* styling the 9th and all following divs */
    .result-selection:nth-of-type(n+9) {
        opacity: 0.1;
    }
}
```

- increased history row to 8 to make fade-out effect more apparent

#### Constraints detected: 

The updated styling in `.css` introduces magic numbers (styling change from the 5th and 9th child). And there is no coherency between these numbers and the clean-up function in the JS script.

I think this could be addressed by sharing this variable (`maxHistoryRows`) from the `.js` file across the `.css` file. 
I will need to learn how to do that. 

--- 

What do you guys think? 
